### PR TITLE
Change RGB to ARGB for charts to fix color quality

### DIFF
--- a/MPChartLib/src/com/github/mikephil/charting/charts/Chart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/Chart.java
@@ -414,8 +414,7 @@ public abstract class Chart<T extends DataSet> extends ViewGroup {
 
     if (mDrawBitmap == null || mDrawCanvas == null) {
 
-      // use RGB_565 for best performance
-      mDrawBitmap = Bitmap.createBitmap(getWidth(), getHeight(), Bitmap.Config.RGB_565);
+      mDrawBitmap = Bitmap.createBitmap(getWidth(), getHeight(), Bitmap.Config.ARGB_8888);
       mDrawCanvas = new Canvas(mDrawBitmap);
     }
 


### PR DESCRIPTION
In order to solve https://getbase.atlassian.net/browse/MD-653 it's needed to set background color for chart.
However, using RGB_565 the result color differs slightly from our activity color (it's a bit whiter). Using ARGB makes the colors identical.